### PR TITLE
feat(auth): 添加对 Nacos 认证的支持; 允许通过环境变量指定默认的命名空间和组; 添加跨平台编译脚本.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: '要发布的标签版本（例如：v1.2.0）'
+        required: true
+        type: string
 
 jobs:
   release:
@@ -13,6 +19,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Set release version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+          else
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          fi
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -35,17 +49,18 @@ jobs:
         run: |
           cd dist
           chmod +x nacos-cli_linux_*
-          tar -czf nacos-cli_${GITHUB_REF_NAME}_linux_amd64.tar.gz nacos-cli_linux_amd64
-          tar -czf nacos-cli_${GITHUB_REF_NAME}_linux_arm64.tar.gz nacos-cli_linux_arm64
-          zip nacos-cli_${GITHUB_REF_NAME}_windows_amd64.zip nacos-cli_windows_amd64.exe
+          tar -czf nacos-cli_${VERSION}_linux_amd64.tar.gz nacos-cli_linux_amd64
+          tar -czf nacos-cli_${VERSION}_linux_arm64.tar.gz nacos-cli_linux_arm64
+          zip nacos-cli_${VERSION}_windows_amd64.zip nacos-cli_windows_amd64.exe
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ env.VERSION }}
           files: |
-            dist/nacos-cli_${{ github.ref_name }}_linux_amd64.tar.gz
-            dist/nacos-cli_${{ github.ref_name }}_linux_arm64.tar.gz
-            dist/nacos-cli_${{ github.ref_name }}_windows_amd64.zip
+            dist/nacos-cli_${{ env.VERSION }}_linux_amd64.tar.gz
+            dist/nacos-cli_${{ env.VERSION }}_linux_arm64.tar.gz
+            dist/nacos-cli_${{ env.VERSION }}_windows_amd64.zip
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Create release directory
+        run: mkdir -p dist
+
+      - name: Build for multiple platforms
+        run: |
+          # Linux AMD64
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o dist/nacos-cli_linux_amd64
+          # Linux ARM64
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o dist/nacos-cli_linux_arm64
+          # Windows AMD64
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o dist/nacos-cli_windows_amd64.exe
+
+      - name: Package binaries
+        run: |
+          cd dist
+          chmod +x nacos-cli_linux_*
+          tar -czf nacos-cli_${GITHUB_REF_NAME}_linux_amd64.tar.gz nacos-cli_linux_amd64
+          tar -czf nacos-cli_${GITHUB_REF_NAME}_linux_arm64.tar.gz nacos-cli_linux_arm64
+          zip nacos-cli_${GITHUB_REF_NAME}_windows_amd64.zip nacos-cli_windows_amd64.exe
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/nacos-cli_${{ github.ref_name }}_linux_amd64.tar.gz
+            dist/nacos-cli_${{ github.ref_name }}_linux_arm64.tar.gz
+            dist/nacos-cli_${{ github.ref_name }}_windows_amd64.zip
+          draft: false
+          prerelease: false
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,19 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o dist/nacos-cli_linux_arm64
           # Windows AMD64
           CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o dist/nacos-cli_windows_amd64.exe
+          # macOS AMD64
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o dist/nacos-cli_darwin_amd64
+          # macOS ARM64
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o dist/nacos-cli_darwin_arm64
 
       - name: Package binaries
         run: |
           cd dist
-          chmod +x nacos-cli_linux_*
+          chmod +x nacos-cli_linux_* nacos-cli_darwin_*
           tar -czf nacos-cli_${VERSION}_linux_amd64.tar.gz nacos-cli_linux_amd64
           tar -czf nacos-cli_${VERSION}_linux_arm64.tar.gz nacos-cli_linux_arm64
+          tar -czf nacos-cli_${VERSION}_darwin_amd64.tar.gz nacos-cli_darwin_amd64
+          tar -czf nacos-cli_${VERSION}_darwin_arm64.tar.gz nacos-cli_darwin_arm64
           zip nacos-cli_${VERSION}_windows_amd64.zip nacos-cli_windows_amd64.exe
 
       - name: Create Release
@@ -60,6 +66,8 @@ jobs:
           files: |
             dist/nacos-cli_${{ env.VERSION }}_linux_amd64.tar.gz
             dist/nacos-cli_${{ env.VERSION }}_linux_arm64.tar.gz
+            dist/nacos-cli_${{ env.VERSION }}_darwin_amd64.tar.gz
+            dist/nacos-cli_${{ env.VERSION }}_darwin_arm64.tar.gz
             dist/nacos-cli_${{ env.VERSION }}_windows_amd64.zip
           draft: false
           prerelease: false

--- a/README.md
+++ b/README.md
@@ -19,9 +19,35 @@
 
 ## 使用
 
-**环境变量**
+### 环境变量
 
-export NACOS_ADDR="http://127.0.0.1:8848/nacos"
+以下是支持的环境变量列表：
+
+| 环境变量 | 说明 | 是否必须 | 默认值 |
+|---------|------|---------|--------|
+| NACOS_ADDR | Nacos 服务器地址 | 是 | http://127.0.0.1:8848/nacos |
+| NACOS_API_VERSION | API 版本 | 否 | v1 |
+| NACOS_USER | 用户名 | 否 | - |
+| NACOS_PASSWD | 密码 | 否 | - |
+| NACOS_NAMESPACE | 命名空间 | 否 | - |
+| NACOS_GROUP | 配置组 | 否 | DEFAULT_GROUP |
+
+### 命令行参数与环境变量优先级
+
+命令行参数的优先级高于环境变量。具体规则如下：
+
+1. 用户名和密码：
+   - 优先使用命令行参数 `-u/--username` 和 `-p/--password`
+   - 如果命令行参数未提供，则使用环境变量 `NACOS_USER` 和 `NACOS_PASSWD`
+   - 如果环境变量也未设置，则不使用认证
+
+2. 命名空间和分组：
+   - 优先使用命令行参数 `-n/--namespace` 和 `-g/--group`
+   - 如果未提供，则使用环境变量 `NACOS_NAMESPACE` 和 `NACOS_GROUP`
+     - 命名空间默认值: ''
+     - 分组默认值：`DEFAULT_GROUP`
+
+### 基本操作
 
 **获取所有配置列表**
 
@@ -45,4 +71,24 @@ nacos-cli edit config common.yaml -n PUBLIC -g DEFAULT_GROUP
 
 ``` bash
 nacos-cli apply -f common.yaml -n public -g DEFAULT_GROUP --id common.yaml
+```
+
+## 使用认证
+
+如果您的 Nacos 服务器配置了认证，您可以通过以下方式提供凭据：
+
+**通过命令行参数：**
+
+```bash
+nacos-cli get config common.yaml -n PUBLIC -g DEFAULT_GROUP -u your_username -p your_password
+```
+> **安全性**：直接在命令行中传递密码或者将密码存储在环境变量中存在安全风险，建议采用环境变量的方式。
+
+**通过环境变量：**
+
+```bash
+export NACOS_USER="your_username"
+export NACOS_PASSWD="your_password"
+
+nacos-cli get config common.yaml -n PUBLIC -g DEFAULT_GROUP
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# 获取版本号
+# 优先使用 git tag，如果没有 tag 则使用 git commit 的短 hash
+VERSION=$(git describe --tags 2>/dev/null || git rev-parse --short HEAD)
+
+# 编译 Linux AMD64
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o dist/nacos-cli_linux_amd64
+
+# 编译 Linux ARM64
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o dist/nacos-cli_linux_arm64
+
+# 编译 Windows AMD64
+CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o dist/nacos-cli_windows_amd64.exe
+
+# 添加可执行权限
+mkdir -p dist
+chmod +x dist/nacos-cli_linux_*
+
+# 打包发布文件
+cd dist
+tar -czf nacos-cli_${VERSION}_linux_amd64.tar.gz nacos-cli_linux_amd64
+tar -czf nacos-cli_${VERSION}_linux_arm64.tar.gz nacos-cli_linux_arm64
+zip nacos-cli_${VERSION}_windows_amd64.zip nacos-cli_windows_amd64.exe

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -24,6 +24,8 @@ var applyCmd = &cobra.Command{
 			NacosOperation: &nacos.NacosOperation{
 				Namespace: namespace,
 				Group:     group,
+				Username:  username,
+				Password:  password,
 			},
 			DataId: dataId,
 			File:   file,

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -32,6 +32,9 @@ var getConfig = &cobra.Command{
 			dataIds, err := nacosClient.AllConfig(nacos.ConfigGetOperation{
 				NacosOperation: &nacos.NacosOperation{
 					Namespace: namespace,
+					Group:     group,
+					Username:  username,
+					Password:  password,
 				},
 			})
 
@@ -53,6 +56,8 @@ var getConfig = &cobra.Command{
 			NacosOperation: &nacos.NacosOperation{
 				Namespace: namespace,
 				Group:     group,
+				Username:  username,
+				Password:  password,
 			},
 			DataId: dataId,
 		})
@@ -68,6 +73,9 @@ var getConfig = &cobra.Command{
 		dataIds, err := nacosClient.AllConfig(nacos.ConfigGetOperation{
 			NacosOperation: &nacos.NacosOperation{
 				Namespace: namespace,
+				Group:     group,
+				Username:  username,
+				Password:  password,
 			},
 		})
 		for _, dataId := range dataIds {
@@ -97,6 +105,8 @@ var editConfig = &cobra.Command{
 			NacosOperation: &nacos.NacosOperation{
 				Namespace: namespace,
 				Group:     group,
+				Username:  username,
+				Password:  password,
 			},
 			DataId: dataId,
 		})
@@ -139,6 +149,8 @@ var editConfig = &cobra.Command{
 			NacosOperation: &nacos.NacosOperation{
 				Namespace: namespace,
 				Group:     group,
+				Username:  username,
+				Password:  password,
 			},
 			DataId:  dataId,
 			Content: string(edited),
@@ -168,6 +180,8 @@ var deleteConfig = &cobra.Command{
 			NacosOperation: &nacos.NacosOperation{
 				Namespace: namespace,
 				Group:     group,
+				Username:  username,
+				Password:  password,
 			},
 			DataId: args[0],
 		})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,8 @@ import (
 
 var namespace string
 var group string
+var username string // 新增：用于存储用户名
+var password string // 新增：用于存储密码
 
 var nacosClient *nacos.Client
 
@@ -34,11 +36,24 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "nacos namespace")
-	rootCmd.PersistentFlags().StringVarP(&group, "group", "g", "DEFAULT_GROUP", "nacos group")
+    // 从环境变量获取默认值
+    defaultNamespace := os.Getenv("NACOS_NAMESPACE")
+    defaultGroup := os.Getenv("NACOS_GROUP")
+    if defaultGroup == "" {
+        defaultGroup = "DEFAULT_GROUP"
+    }
 
-	_ = rootCmd.MarkFlagRequired("namespace")
-	_ = rootCmd.MarkFlagRequired("group")
+    // 设置命令行参数，使用环境变量作为默认值
+    rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", defaultNamespace, "nacos namespace(or os env NACOS_NAMESPACE)")
+    rootCmd.PersistentFlags().StringVarP(&group, "group", "g", defaultGroup, "nacos group(or os env NACOS_GROUP)")
+    rootCmd.PersistentFlags().StringVarP(&username, "username", "u", "", "nacos username(or os env NACOS_USER)")
+    rootCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "nacos password(or os env NACOS_PASSWD)")
 
-	nacosClient = nacos.NewDefaultClient()
+    // 只有当环境变量也没有设置时，才要求必填
+    if defaultNamespace == "" {
+        _ = rootCmd.MarkFlagRequired("namespace")
+    }
+
+    // 初始化客户端
+    nacosClient = nacos.NewDefaultClient()
 }

--- a/pkg/nacos/config.go
+++ b/pkg/nacos/config.go
@@ -63,11 +63,21 @@ func (c *Client) DeleteConfig(operation ConfigDeleteOperation) error {
 	}
 
 	// 请求参数
-	req.URL.RawQuery = url.Values{
+	params := url.Values{
 		"dataId": []string{operation.DataId},
 		"group":  []string{operation.Group},
 		"tenant": []string{operation.Namespace},
-	}.Encode()
+	}
+
+	// 添加认证参数
+	username, password := c.getAuthInfo(operation.NacosOperation)
+	if username!= "" && password!= "" {
+		params.Add("username", username)
+		params.Add("password", password)
+	}
+
+	// 设置请求参数
+	req.URL.RawQuery = params.Encode()
 
 	resp, err := http.DefaultClient.Do(req)
 

--- a/pkg/nacos/types.go
+++ b/pkg/nacos/types.go
@@ -10,6 +10,8 @@ type NacosConfig struct {
 type NacosOperation struct {
 	Namespace string // 命名空间
 	Group     string // 组
+	Username  string // 用户名
+	Password  string // 密码
 }
 
 // ConfigEditOperation 配置更新操作


### PR DESCRIPTION
- 新增命令行参数和环境变量支持，允许用户提供用户名和密码进行 Nacos 认证。
- 修改了客户端初始化逻辑，以支持认证信息的传递，并在请求时自动添加认证信息
- 允许通过环境变量指定默认的命名空间和组。
- 添加自动构建脚本。